### PR TITLE
[Bug] fix fe and broker can not get default config 

### DIFF
--- a/manager/dm-server/src/main/java/org/apache/doris/stack/service/control/DorisClusterService.java
+++ b/manager/dm-server/src/main/java/org/apache/doris/stack/service/control/DorisClusterService.java
@@ -301,7 +301,7 @@ public class DorisClusterService {
         } else if (moduleName.equals(ServerAndAgentConstant.FE_NAME)) {
             for (String key : ConfigDefault.FE_CONFIG_DEDAULT.keySet()) {
                 DeployConfigItem configItem = new DeployConfigItem();
-                String value = ConfigDefault.BE_CONFIG_DEDAULT.get(key);
+                String value = ConfigDefault.FE_CONFIG_DEDAULT.get(key);
                 if (key.equals(ConfigDefault.FE_LOG_CONFIG_NAME) || key.equals(ConfigDefault.FE_META_CONFIG_NAME)) {
                     value = installInfo + "/" + ServerAndAgentConstant.FE_NAME + value;
                 }
@@ -313,7 +313,7 @@ public class DorisClusterService {
         } else {
             for (String key : ConfigDefault.BROKER_CONFIG_DEDAULT.keySet()) {
                 DeployConfigItem configItem = new DeployConfigItem();
-                String value = ConfigDefault.BE_CONFIG_DEDAULT.get(key);
+                String value = ConfigDefault.BROKER_CONFIG_DEDAULT.get(key);
                 configItem.setKey(key);
                 configItem.setValue(value);
 


### PR DESCRIPTION
## Problem Summary:

fix fe and broker can not get default config
## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
