### PR TITLE
remove user from cluster space when removing it from admin role

### DIFF
--- a/manager/dm-server/src/main/java/org/apache/doris/stack/component/DorisManagerUserSpaceComponent.java
+++ b/manager/dm-server/src/main/java/org/apache/doris/stack/component/DorisManagerUserSpaceComponent.java
@@ -304,8 +304,12 @@ public class DorisManagerUserSpaceComponent extends BaseService {
                 if (adminUserId < 0) {
                     continue;
                 }
-                // Delete the user from the space administrator role, but will not delete the user from the space?
+                // Delete the user from the space administrator role
                 membershipRepository.deleteByUserIdAndGroupId(clusterInfo.getAdminGroupId(), adminUserId);
+
+                // also delete the user form all user role and cluster space
+                membershipRepository.deleteByUserIdAndGroupId(clusterInfo.getAllUserGroupId(), adminUserId);
+                clusterUserMembershipRepository.deleteByUserIdAndClusterId(adminUserId, clusterInfo.getId());
             }
 
         }


### PR DESCRIPTION
## Problem Summary:

Current cluster space only support admin role to operate the cluster, when admin user removes others from admin role group, they should also be remove from cluster space and all_user role group.

## Checklist

1. Does it affect the original behavior: Yes
2. Has unit tests been added: No
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No
