### PR TITLE
[fix] check if user is empty when deleting palo user

### DIFF
--- a/manager/dm-server/src/main/java/org/apache/doris/stack/component/DorisManagerUserSpaceComponent.java
+++ b/manager/dm-server/src/main/java/org/apache/doris/stack/component/DorisManagerUserSpaceComponent.java
@@ -447,20 +447,24 @@ public class DorisManagerUserSpaceComponent extends BaseService {
         // delete cluster information
         clusterInfoRepository.deleteById(spaceId);
 
-        // delete cluster configuration
-        log.debug("delete cluster {} config infos.", spaceId);
-        settingComponent.deleteAdminSetting(spaceId);
+        try {
+            // delete cluster configuration
+            log.debug("delete cluster {} config infos.", spaceId);
+            settingComponent.deleteAdminSetting(spaceId);
 
-        deleteClusterPermissionInfo(clusterInfo);
+            deleteClusterPermissionInfo(clusterInfo);
 
-        // delete user information
-        log.debug("delete cluster {} all user membership.", spaceId);
-        clusterUserMembershipRepository.deleteByClusterId(spaceId);
+            // delete user information
+            log.debug("delete cluster {} all user membership.", spaceId);
+            clusterUserMembershipRepository.deleteByClusterId(spaceId);
 
-        // TODO: In order to be compatible with the deleted content of spatial information before, it is put here.
-        //  If the interface that releases both cluster and physical resources is implemented later,
-        //  it will be unified in the current doriscluster processing operation
-        clusterManager.deleteClusterOperation(clusterInfo);
+            // TODO: In order to be compatible with the deleted content of spatial information before, it is put here.
+            //  If the interface that releases both cluster and physical resources is implemented later,
+            //  it will be unified in the current doriscluster processing operation
+            clusterManager.deleteClusterOperation(clusterInfo);
+        } catch (Exception e) {
+            log.warn("delete space {} related information failed", spaceId, e);
+        }
     }
 
     private void deleteClusterPermissionInfo(ClusterInfoEntity clusterInfo) throws Exception {

--- a/manager/manager/src/main/java/org/apache/doris/stack/connector/PaloQueryClient.java
+++ b/manager/manager/src/main/java/org/apache/doris/stack/connector/PaloQueryClient.java
@@ -77,6 +77,10 @@ public class PaloQueryClient extends PaloClient {
     }
 
     public void deleteUser(String ns, String db, ClusterInfoEntity entity, String userName) {
+        if (userName == null) {
+            log.warn("user name is null");
+            return;
+        }
         if (userName.startsWith("Analyzer") || userName.startsWith("Administrators")) {
             try {
                 String deleteSql = "DROP USER '" + userName + "'@'%'";


### PR DESCRIPTION
## Checklist(Required)

1. Does it affect the original behavior: Yes
2. Has unit tests been added: No
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No

