### PR TITLE
Fix the path problem of broker when taking over doris cluster

### DIFF
--- a/manager/dm-common/src/main/java/org/apache/doris/manager/common/util/ServerAndAgentConstant.java
+++ b/manager/dm-common/src/main/java/org/apache/doris/manager/common/util/ServerAndAgentConstant.java
@@ -17,6 +17,10 @@
 
 package org.apache.doris.manager.common.util;
 
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
 public class ServerAndAgentConstant {
 
     private ServerAndAgentConstant() {
@@ -34,6 +38,7 @@ public class ServerAndAgentConstant {
 
     // The path of borker module initialization when the installation package is downloaded
     public static final String BROKER_INIT_SUB_DIR = "apache_hdfs_broker";
+    public static final String BAIDU_BROKER_INIT_SUB_DIR = "baidu_doris_broker";
 
     public static final String DORIS_INSTALL_HOME_EVN = "DORIS_INSTALL_HOME";
     public static final String DORIS_PACKAGE_URL_ENV = "DORIS_PACKAGE_URL";
@@ -41,6 +46,7 @@ public class ServerAndAgentConstant {
     public static final String FE_PID_FILE = "fe.pid";
     public static final String BE_PID_FILE = "be.pid";
     public static final String BROKER_PID_FILE = "apache_hdfs_broker.pid";
+    public static final String BAIDU_BROKER_PID_FILE = "baidu_doris_broker.pid";
 
     public static final String FE_PID_NAME = "PaloFe";
     public static final String BE_PID_NAME = "palo_be";
@@ -57,6 +63,7 @@ public class ServerAndAgentConstant {
     public static final String FE_CONF_FILE = "fe.conf";
     public static final String BE_CONF_FILE = "be.conf";
     public static final String BROKER_CONF_FILE = "apache_hdfs_broker.conf";
+    public static final String BAIDU_BROKER_CONF_FILE = "baidu_doris_broker.conf";
 
     public static final String PACKAGE_DOWNLOAD_SCRIPT = "download_doris.sh";
 
@@ -67,5 +74,19 @@ public class ServerAndAgentConstant {
 
     public static final String BE_HEARTBEAT_SERVICE = "be_heartbeat";
     public static final String BROKER_PRC_SERVICE = "broker_rpc";
+
+    public static final Map<String, String> BAIDU_BROKER_CONFIG_DEDAULT;
+
+    static {
+        BAIDU_BROKER_CONFIG_DEDAULT = Maps.newHashMap();
+        BAIDU_BROKER_CONFIG_DEDAULT.put("afs_filesystem_impl", "org.apache.hadoop.fs.DFileSystem");
+        BAIDU_BROKER_CONFIG_DEDAULT.put("hdfs_filesystem_impl", "org.apache.hadoop.hdfs.DistributedFileSystem");
+        BAIDU_BROKER_CONFIG_DEDAULT.put("bos_filesystem_impl", "org.apache.hadoop.fs.bos.BaiduBosFileSystem");
+        BAIDU_BROKER_CONFIG_DEDAULT.put("afs_agent_port", "20001");
+        BAIDU_BROKER_CONFIG_DEDAULT.put("hdfs_agent_port", "20002");
+        BAIDU_BROKER_CONFIG_DEDAULT.put("afs_client_auth_method", "3");
+        BAIDU_BROKER_CONFIG_DEDAULT.put("hdfs_client_auth_method", "2");
+        BAIDU_BROKER_CONFIG_DEDAULT.put("bos_client_auth_method", "2");
+    }
 
 }

--- a/manager/dm-server/src/main/java/org/apache/doris/stack/control/manager/DorisClusterInstanceManager.java
+++ b/manager/dm-server/src/main/java/org/apache/doris/stack/control/manager/DorisClusterInstanceManager.java
@@ -51,7 +51,7 @@ public class DorisClusterInstanceManager {
 
     public long initOperation(long clusterId, ClusterModuleEntity moudle, long nodeId) {
         // TODO:Judge whether node can deploy this instance
-        log.info("create a new instance for cluster {} moudle {} on node {}", clusterId, moudle.getId(), nodeId);
+        log.info("create a new instance for cluster {} moudle {} on node {}", clusterId, moudle.getModuleName(), nodeId);
         ResourceNodeEntity nodeEntity = nodeRepository.findById(nodeId).get();
 
         ClusterInstanceEntity instanceEntity = new ClusterInstanceEntity(clusterId, moudle.getId(), nodeId,

--- a/manager/dm-server/src/main/java/org/apache/doris/stack/control/manager/DorisClusterModuleManager.java
+++ b/manager/dm-server/src/main/java/org/apache/doris/stack/control/manager/DorisClusterModuleManager.java
@@ -59,7 +59,7 @@ public class DorisClusterModuleManager {
     private DorisClusterInstanceManager instanceManager;
 
     public long initOperation(long clusterId, DorisClusterModuleResourceConfig resourceConfig) {
-        log.info("create module for cluster {}", clusterId);
+        log.info("create module {} for cluster {}", resourceConfig.getModuleName(), clusterId);
         ClusterModuleEntity moduleEntity = new ClusterModuleEntity(clusterId, resourceConfig.getModuleName());
 
         ClusterModuleEntity newModuleEntity = clusterModuleRepository.save(moduleEntity);


### PR DESCRIPTION
# Proposed changes

Issue Number: close #xxx

## Problem Summary:

Describe the overview of changes.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments
The actual broker deployment path of Doris cluster may be apache_hdfs_broker or baidu_doris_broker, which should be compatible when taking over the deployed Doris cluster.

