### PR TITLE
[feature] can set agent port in frontend when creating a new cluster

### DIFF
--- a/frontend/public/locales/en-us.json
+++ b/frontend/public/locales/en-us.json
@@ -341,5 +341,8 @@
     "TableDescription": "Table Description",
     "CreateTime": "Create Time",
     "UpdateTime": "Update Time",
-    "UpdateTimeHelper": "Records the time when the last table structure change occurred"
+    "UpdateTimeHelper": "Records the time when the last table structure change occurred",
+    
+    "Sync successfully, please refresh the page": "Sync successfully, please refresh the page",
+    "Sync failed": "Sync failed"
 }

--- a/frontend/public/locales/zh-cn.json
+++ b/frontend/public/locales/zh-cn.json
@@ -354,6 +354,9 @@
     "TableDescription": "数据表描述信息",
     "CreateTime": "创建时间",
     "UpdateTime": "最近修改时间",
-    "UpdateTimeHelper": "记录该表最近发生表结构变更的时间"
+    "UpdateTimeHelper": "记录该表最近发生表结构变更的时间",
+
+    "Sync successfully, please refresh the page": "同步成功，请刷新页面" ,
+    "Sync failed": "同步失败"
 }
 

--- a/frontend/src/components/common-header/header.tsx
+++ b/frontend/src/components/common-header/header.tsx
@@ -44,7 +44,7 @@ export function Header(props: HeaderProps) {
                 <span styleName="common-header-icon">{props.icon}</span>
                 <span styleName="common-header-name">{props.title}</span>
             </div>
-            <div styleName="common-header-refresh">
+            {/* <div styleName="common-header-refresh">
                 <SyncOutlined
                     spin={loading}
                     onClick={() => {
@@ -52,7 +52,7 @@ export function Header(props: HeaderProps) {
                         setLoading(true);
                     }}
                 />
-            </div>
+            </div> */}
         </div>
     );
 }

--- a/frontend/src/routes/space/access-cluster/access-cluster.tsx
+++ b/frontend/src/routes/space/access-cluster/access-cluster.tsx
@@ -18,7 +18,6 @@
 import ProCard from '@ant-design/pro-card';
 import { Button, message, Row, Space, Steps } from 'antd';
 import React, { useEffect, useState } from 'react';
-import { pathToRegexp } from 'path-to-regexp';
 import { NewSpaceInfoContext } from '@src/common/common.context';
 import { useForm } from 'antd/lib/form/Form';
 import { AccessClusterStepsEnum } from './access-cluster.data';
@@ -120,11 +119,13 @@ export function AccessCluster() {
                 sshUser: value.sshUser,
             };
             params.installInfo = value.installInfo;
+            params.agentPort = value.agentPort ? parseInt(value.agentPort) : value.agentPort;
             isParamsValid =
                 checkParam(params.authInfo.sshUser, '请填写SSH用户') &&
                 checkParam(params.authInfo.sshPort, '请填写SSH端口') &&
                 checkParam(params.authInfo.sshKey, '请填写SSH私钥') &&
-                checkParam(params.installInfo, '请填写安装路径');
+                checkParam(params.installInfo, '请填写安装路径') &&
+                checkParam(params.agentPort, '请填写Agent启动端口');
         }
         if (!isParamsValid) return;
         setLoading(true);

--- a/frontend/src/routes/space/access-cluster/steps/managed-options/index.module.less
+++ b/frontend/src/routes/space/access-cluster/steps/managed-options/index.module.less
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+.input {
+    width: 400px;
+}

--- a/frontend/src/routes/space/access-cluster/steps/managed-options/managed-options.tsx
+++ b/frontend/src/routes/space/access-cluster/steps/managed-options/managed-options.tsx
@@ -20,11 +20,12 @@ import React, { useContext, useEffect } from 'react';
 import ProCard from '@ant-design/pro-card';
 import { NewSpaceInfoContext } from '@src/common/common.context';
 import TextArea from 'antd/lib/input/TextArea';
+import styles from './index.module.less';
 
 export function ManagedOptions(props: any) {
     const { form, reqInfo } = useContext(NewSpaceInfoContext);
     useEffect(() => {
-        form.setFieldsValue({...reqInfo.authInfo});
+        form.setFieldsValue({ ...reqInfo.authInfo });
     }, [reqInfo.cluster_id]);
     return (
         <ProCard title={<h2>托管选项</h2>} headerBordered>
@@ -62,15 +63,20 @@ export function ManagedOptions(props: any) {
             <Form
                 form={form}
                 name="basic"
-                labelCol={{ span: 2 }}
-                wrapperCol={{ span: 10 }}
                 initialValues={{
                     installInfo: reqInfo.installInfo,
                 }}
                 autoComplete="off"
             >
                 <Form.Item label="安装路径" name="installInfo" rules={[{ required: true, message: '请输入安装路径' }]}>
-                    <Input />
+                    <Input className={styles.input} />
+                </Form.Item>
+                <Form.Item
+                    label="Agent启动端口"
+                    name="agentPort"
+                    rules={[{ required: true, message: '请输入Agent启动端口' }]}
+                >
+                    <Input className={styles.input} />
                 </Form.Item>
             </Form>
         </ProCard>

--- a/frontend/src/routes/space/new-cluster/new-cluster.tsx
+++ b/frontend/src/routes/space/new-cluster/new-cluster.tsx
@@ -115,8 +115,11 @@ export function NewCluster() {
         if (value && step === NewClusterStepsEnum['install-options']) {
             params.installInfo = value.installDir;
             params.packageInfo = value.packageUrl;
+            params.agentPort = value.agentPort ? parseInt(value.agentPort) : value.agentPort;
             isParamsValid =
-                checkParam(params.installInfo, '请填写代码包路径') && checkParam(params.packageInfo, '请填写安装路径');
+                checkParam(params.installInfo, '请填写代码包路径') &&
+                checkParam(params.packageInfo, '请填写安装路径') &&
+                checkParam(params.agentPort, '请填写Agent启动端口');
         }
         if (value && step === NewClusterStepsEnum['cluster-plan']) {
             params.nodeConfig = value.nodeConfig;

--- a/frontend/src/routes/space/new-cluster/steps/install-options/index.module.less
+++ b/frontend/src/routes/space/new-cluster/steps/install-options/index.module.less
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+.input {
+    width: 400px;
+}

--- a/frontend/src/routes/space/new-cluster/steps/install-options/install-options.tsx
+++ b/frontend/src/routes/space/new-cluster/steps/install-options/install-options.tsx
@@ -19,9 +19,10 @@ import { Form, Input, PageHeader } from 'antd';
 import React, { useContext } from 'react';
 import ProCard from '@ant-design/pro-card';
 import { NewSpaceInfoContext } from '@src/common/common.context';
+import styles from './index.module.less';
 
 export function InstallOptions(props: any) {
-    const {form} = useContext(NewSpaceInfoContext);
+    const { form } = useContext(NewSpaceInfoContext);
     return (
         <ProCard title={<h2>安装选项</h2>} headerBordered>
             <PageHeader className="site-page-header" title="获取安装包" style={{ paddingLeft: 0 }} />
@@ -31,30 +32,25 @@ export function InstallOptions(props: any) {
                     若Manager节点可访问公网，推荐直接使用预编译安装包地址；若Manager节点不可访问公网，推荐自行搭建http服务提供安装包。
                 </div>
             </p>
-            <Form
-                form={form}
-                name="basic"
-                labelCol={{ span: 2 }}
-                wrapperCol={{ span: 10 }}
-                autoComplete="off"
-            >
+            <Form form={form} name="basic" autoComplete="off">
                 <Form.Item label="代码包路径" name="packageUrl" rules={[{ required: true, message: '请输入安装路径' }]}>
-                    <Input />
+                    <Input className={styles.input} />
                 </Form.Item>
             </Form>
             <PageHeader className="site-page-header" title="指定安装路径" style={{ paddingLeft: 0 }} />
             <div>
                 <p>Doris与Doris Manager Agent将安装至该目录下。请确保该目录为Doris及相关组件专用。</p>
             </div>
-            <Form
-                form={form}
-                name="basic"
-                labelCol={{ span: 2 }}
-                wrapperCol={{ span: 10 }}
-                autoComplete="off"
-            >
+            <Form form={form} name="basic" autoComplete="off">
                 <Form.Item label="安装路径" name="installDir" rules={[{ required: true, message: '请输入安装路径' }]}>
-                    <Input />
+                    <Input className={styles.input} />
+                </Form.Item>
+                <Form.Item
+                    label="Agent启动端口"
+                    name="agentPort"
+                    rules={[{ required: true, message: '请输入Agent启动端口' }]}
+                >
+                    <Input className={styles.input} />
                 </Form.Item>
             </Form>
         </ProCard>

--- a/frontend/src/routes/space/space.interface.ts
+++ b/frontend/src/routes/space/space.interface.ts
@@ -40,12 +40,11 @@ export interface ISpaceParam {
     spaceAdminUsers: number[];
 }
 
-
 export interface ISpaceUser {
     name: string;
     email: string;
     id: number;
-    is_active: boolean
+    is_active: boolean;
 }
 export type IRequiredMark = boolean | 'optional';
 
@@ -88,4 +87,5 @@ export interface ClusterAccessParams {
     clusterAccessInfo?: ClusterAccessInfo;
     installInfo?: string;
     spaceInfo?: SpaceInfo;
+    agentPort?: number;
 }

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -76,3 +76,7 @@ export function showName(name: string): string {
     }
     return name;
 }
+
+export function delay(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Problem Summary:

1. Users can set agent port in frontend when creating a new cluster.

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
