### PR TITLE
[fix] fix variable param is used in multi threads

### DIFF
--- a/manager/dm-server/src/main/java/org/apache/doris/stack/control/manager/ResourceClusterManager.java
+++ b/manager/dm-server/src/main/java/org/apache/doris/stack/control/manager/ResourceClusterManager.java
@@ -115,10 +115,6 @@ public class ResourceClusterManager {
                 PMResourceClusterAccessInfo.class);
         // TODO:The path can be set separately for each machine later
         List<ResourceNodeEntity> nodeEntities = nodeRepository.getByResourceClusterId(resourceClusterId);
-        AgentInstallEventConfigInfo configInfo = new AgentInstallEventConfigInfo();
-        configInfo.setSshUser(accessInfo.getSshUser());
-        configInfo.setSshPort(accessInfo.getSshPort());
-        configInfo.setSshKey(accessInfo.getSshKey());
 
         log.debug("check agent port for resource cluster {} all nodes", resourceClusterId);
 
@@ -127,6 +123,11 @@ public class ResourceClusterManager {
         // but it may expose this problem early if the port has been used.
         List<Pair<ResourceNodeEntity, CompletableFuture<Boolean>>> nodeFutures = new ArrayList<>();
         for (ResourceNodeEntity nodeEntity : nodeEntities) {
+            AgentInstallEventConfigInfo configInfo = new AgentInstallEventConfigInfo();
+            configInfo.setSshUser(accessInfo.getSshUser());
+            configInfo.setSshPort(accessInfo.getSshPort());
+            configInfo.setSshKey(accessInfo.getSshKey());
+
             CompletableFuture<Boolean> portCheckFuture = CompletableFuture.supplyAsync(() -> {
                 try {
                     nodeAndAgentManager.checkSshConnect(nodeEntity, configInfo);
@@ -169,6 +170,11 @@ public class ResourceClusterManager {
         log.debug("install agent for resource cluster {} all nodes", resourceClusterId);
         for (ResourceNodeEntity nodeEntity : nodeEntities) {
             log.info("start to install agent to {} node {}", nodeEntity.getId(), nodeEntity.getHost());
+            AgentInstallEventConfigInfo configInfo = new AgentInstallEventConfigInfo();
+            configInfo.setSshUser(accessInfo.getSshUser());
+            configInfo.setSshPort(accessInfo.getSshPort());
+            configInfo.setSshKey(accessInfo.getSshKey());
+
             nodeAndAgentManager.installAgentOperation(nodeEntity, configInfo, requestId);
         }
     }


### PR DESCRIPTION
## Problem Summary:

config param is used in multi threads when installing agent sync

## Checklist(Required)

1. Does it affect the original behavior: Yes
2. Has unit tests been added: N
3. Has document been added or modified: No Need
4. Does it need to update dependencies: No
5. Are there any changes that cannot be rolled back: No
