### PR TITLE
[fix] ubuntu check jdk dependencies, jdk is not available: /root/.bash_profile

### DIFF
--- a/manager/dm-server/src/main/java/org/apache/doris/stack/control/manager/ResourceNodeAndAgentManager.java
+++ b/manager/dm-server/src/main/java/org/apache/doris/stack/control/manager/ResourceNodeAndAgentManager.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Paths;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -343,6 +344,21 @@ public class ResourceNodeAndAgentManager {
 
         //check jdk
         // JDK_CHECK stage
+        final String checkSystem = "cat /etc/os-release";
+        ssh.setCommand(checkSystem);
+        if (!ssh.run()) {
+            log.error("View system failures", ssh.getErrorResponse());
+            return;
+        }
+        if (ssh.getStdoutResponse().toLowerCase(Locale.ROOT).contains("ubuntu")) {
+            final String mkdirBashProfile = "if test -f ~/.bash_profile;then echo ok;else touch ~/.bash_profile;fi";
+            ssh.setCommand(mkdirBashProfile);
+            if (!ssh.run()) {
+                log.error("Create file fail", ssh.getErrorResponse());
+                return;
+            }
+        }
+        log.info("Create .bash_profile successfully");
         final String checkJavaHome = "source /etc/profile && source ~/.bash_profile && java -version && echo $JAVA_HOME";
         ssh.setCommand(checkJavaHome);
         if (!ssh.run()) {


### PR DESCRIPTION
## Problem Summary:

fix ubuntu check jdk dependencies, jdk is not available: /root/.bash_profile

## Checklist(Required)

1. Does it affect the original behavior: (Yes/No/I Don't know)
2. Has unit tests been added: (Yes/No/No Need)
3. Has document been added or modified: (Yes/No/No Need)
4. Does it need to update dependencies: (Yes/No)
5. Are there any changes that cannot be rolled back: (Yes/No)

## Further comments

If this is a relatively large or complex change, kick off the discussion at [dev@doris.apache.org](mailto:dev@doris.apache.org) by explaining why you chose the solution you did and what alternatives you considered, etc...
